### PR TITLE
feat: 카카오맵 api 연동 및 컴포넌트 개발

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "15.3.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-kakao-maps-sdk": "^1.2.0",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.8"
       },
@@ -25,6 +26,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
+        "kakao.maps.d.ts": "^0.1.40",
         "tailwindcss": "^4.1.10",
         "typescript": "^5"
       }
@@ -1678,6 +1680,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6637,6 +6648,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7691,6 +7708,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.2.0.tgz",
+      "integrity": "sha512-ptyHhtSbvyza+9IAf6TXjE4ZhwwLbXR6avgNM2ju5xed2+fDwJ+gJDFSqhfsKbvFn9K9+3I+dY3JrqruwsGNBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "15.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-kakao-maps-sdk": "^1.2.0",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.8"
   },

--- a/src/app/event-detail/components/KakaoMap.tsx
+++ b/src/app/event-detail/components/KakaoMap.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Map, MapMarker } from "react-kakao-maps-sdk";
+import useKakaoLoader from "./useKakaoLoader";
+import { useEffect, useState } from "react";
+
+interface KakaoMapProps {
+  address?: string;
+  lat?: number;
+  lng?: number;
+}
+
+const KakaoMapPage = ({ address, lat, lng }: KakaoMapProps) => {
+  const [coordinates, setCoordinates] = useState({
+    lat: lat ?? 33.450701,
+    lng: lng ?? 126.570667,
+  });
+
+  useKakaoLoader();
+
+  useEffect(() => {
+    // 위도/경도가 직접 작성할 경우
+    if (lat && lng) {
+      setCoordinates({ lat, lng });
+      return;
+    }
+
+    // 주소가 있는 경우: Geocoder 사용
+    if (address && window.kakao && window.kakao.maps) {
+      const geocoder = new window.kakao.maps.services.Geocoder();
+
+      geocoder.addressSearch(address, (result, status) => {
+        if (status === window.kakao.maps.services.Status.OK) {
+          const { x, y } = result[0];
+          setCoordinates({ lat: parseFloat(y), lng: parseFloat(x) });
+        } else {
+          console.error("주소 검색 실패:", address);
+        }
+      });
+    }
+  }, [address, lat, lng]);
+
+  const handleCopyLink = () => {
+    const kakaoLink = `https://map.kakao.com/link/map/${address ?? ""},${
+      coordinates.lat
+    },${coordinates.lng}`;
+    navigator.clipboard.writeText(kakaoLink).then(() => {
+      window.open(kakaoLink, "_blank");
+    });
+  };
+
+  return (
+    <Map
+      id="map"
+      center={coordinates}
+      className="w-full h-[200px] relative border-divider-1 border-[0.8px]"
+      level={3}
+    >
+      <MapMarker position={coordinates} />
+      <div className="flex justify-between w-full items-center py-[8px]">
+        <p className="flex items-center font-[600] text-[14px] text-text-5">
+          📍 {address}
+        </p>
+
+        <p
+          className="text-[12px] font-[400] text-text-3"
+          onClick={handleCopyLink}
+        >
+          복사
+        </p>
+      </div>
+    </Map>
+  );
+};
+
+export default KakaoMapPage;

--- a/src/app/event-detail/components/useKakaoLoader.ts
+++ b/src/app/event-detail/components/useKakaoLoader.ts
@@ -1,0 +1,10 @@
+import { useKakaoLoader as useKakaoLoaderOrigin } from "react-kakao-maps-sdk";
+
+const KAKAO_API_KEY = process.env.NEXT_PUBLIC_KAKAO_MAP_KEY;
+
+export default function useKakaoLoader() {
+  useKakaoLoaderOrigin({
+    appkey: `${KAKAO_API_KEY}`,
+    libraries: ["clusterer", "drawing", "services"],
+  });
+}

--- a/src/app/event-detail/page.tsx
+++ b/src/app/event-detail/page.tsx
@@ -6,6 +6,7 @@ import Twitter from "@/svgs/Twitter.svg";
 import Clock from "@/svgs/Clock.svg";
 import Location from "@/svgs/Location.svg";
 import Place from "@/svgs/Place.svg";
+import KakaoMap from "./components/KakaoMap";
 
 const Page = () => {
   return (
@@ -126,6 +127,14 @@ const Page = () => {
           </div>
         </div>
       </div>
+
+      <div className="p-[24px]">
+        <h3 className="flex justify-start items-center w-full font-[700] text-[16px] text-text-5 mb-[12px]">
+          위치
+        </h3>
+        <KakaoMap address="서울특별시 마포구 와우산로 29바길 10" />
+      </div>
+
       <div className="p-[24px]">
         <div className="flex justify-between w-full items-center mb-[16px]">
           <h3 className="flex items-center font-[700] text-[16px] text-text-5">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,13 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.js"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next.config.js",
+    "src/app/event-detail/components/KakaoMap.js"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Kakao Map 컴포넌트에 주소 또는 좌표 기반 위치 표시 기능 추가
- 주소가 있을 경우 Kakao Maps Geocoder API로 위도, 경도 변환 후 지도와 마커 표시
- Kakao Maps SDK 로더 커스텀 훅(useKakaoLoader) 분리 및 환경 변수 적용
- SDK 로드 시 clusterer, drawing, services 라이브러리 옵션 포함